### PR TITLE
Fix bailing when one STREAM_ARRAY_SIZE does not compile

### DIFF
--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -159,11 +159,11 @@ build_images()
 			echo $CC_CMD
 			$CC_CMD
 			if [ $? -ne 0 ]; then
-				if [ $use_cache -eq $base_cache_size ]; then
+				if [ -z $streams_exec ]; then
 					echo Compilation of streams failed.
 					exit 1
 				else
-					echo Could not compile streams with $((use_cache/1024))KB size, skipping
+					echo Could not compile streams with use_cache size, skipping
 				fi
 			else
 				if [[ $streams_exec == "" ]]; then

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -164,14 +164,13 @@ build_images()
 					exit 1
 				else
 					echo Could not compile streams with $((use_cache/1024))KB size, skipping
-					continue
 				fi
-			fi
-
-			if [[ $streams_exec == "" ]]; then
-				streams_exec=$stream
 			else
-				streams_exec=$streams_exec" "$stream
+				if [[ $streams_exec == "" ]]; then
+					streams_exec=$stream
+				else
+					streams_exec=$streams_exec" "$stream
+				fi
 			fi
 
 			use_cache=`echo ${base_cache_size}*1024*${multiple_size} | bc`

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -155,16 +155,23 @@ build_images()
 				fi
  			fi
 
+			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options"
+			echo $CC_CMD
+			$CC_CMD
+			if [ $? -ne 0 ]; then
+				if [ $use_cache -eq $base_cache_size ]; then
+					echo Compilation of streams failed.
+					exit 1
+				else
+					echo Could not compile streams with $((use_cache/1024))KB size, skipping
+					continue
+				fi
+			fi
+
 			if [[ $streams_exec == "" ]]; then
 				streams_exec=$stream
 			else
 				streams_exec=$streams_exec" "$stream
-			fi
-			echo gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options
-			gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic
-			if [ $? -ne 0 ]; then
-				echo Compilation of streams failed.
-				exit 1
 			fi
 
 			use_cache=`echo ${base_cache_size}*1024*${multiple_size} | bc`

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -155,8 +155,8 @@ build_images()
 				fi
  			fi
 
-			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options"
-			echo $CC_CMD
+			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic"
+			echo $CC_CMD >> streams_build_options
 			$CC_CMD
 			if [ $? -ne 0 ]; then
 				if [ -z $streams_exec ]; then

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -163,7 +163,7 @@ build_images()
 					echo Compilation of streams failed.
 					exit 1
 				else
-					echo Could not compile streams with use_cache size, skipping
+					echo Could not compile streams with $use_cache size, skipping
 				fi
 			else
 				if [[ $streams_exec == "" ]]; then

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -159,7 +159,7 @@ build_images()
 			echo $CC_CMD >> streams_build_options
 			$CC_CMD
 			if [ $? -ne 0 ]; then
-				if [ -z $streams_exec ]; then
+				if [ -z "$streams_exec" ]; then
 					echo Compilation of streams failed.
 					exit 1
 				else


### PR DESCRIPTION
Currently: If any sizes of streams fails the entire wrapper fails, this can cause issues with some ARM systems.

With this PR if a size above the max cache size fails to compile,  it simply skips that size.