### PR TITLE
Fix Arm build to allow larger array sizes

### DIFF
--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -140,7 +140,7 @@ build_images()
 	if [[ "${arch}" == "x86_64" ]]; then
 		MOPT="-m64"
 	else
-		MOPT=""
+		MOPT="-mno-outline-atomics"
 	fi
 
         arch=`uname -m`	


### PR DESCRIPTION
Currently the RHEL compiler + linker has an issue when combining LSE (-moutline-atomics, the default as of RHEL 9) with large static allocations and -mcmodel=large.  We previously worked around this by ignoring the errors and marching on with life, but if we just disable LSE (-mno-outline-atomics) then we can test all the array sizes we like which I think is a suitable tradeoff for the small performance hit of disabling LSE.