### PR TITLE
Include optimization level in results.csv

### DIFF
--- a/streams/streams_run
+++ b/streams/streams_run
@@ -233,6 +233,7 @@ retrieve_results()
 #
 retrieve_sys_config()
 {
+        echo "% Optimization level: ${1}" >> ../results_${test_name}.csv
 	streams_vers=`grep "^STREAM version" stream* | cut -d':' -f 3 | cut -d' ' -f2 | sort -u`
 	$TOOLS_BIN/test_header_info --results_file ../results_${test_name}.csv --host $to_configuration --sys_type $to_sys_type \
           --tuned $to_tuned_setting --results_version $streams_wrapper_version --test_name $test_name \


### PR DESCRIPTION
#37 removed lines from the results.csv that specify the compiler optimization level used. This label was very useful because by default the wrapper runs both -O2 and -O3 levels and puts the results in the same file.

This change has been tested and produces the expected result.
![Screenshot From 2024-12-02 11-28-25](https://github.com/user-attachments/assets/3b3b74ac-a268-4d54-8d56-e5bea3b4b149)
