### PR TITLE
Cap the size of the array based on the amount of freemem

### DIFF
--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -159,6 +159,20 @@ build_images()
  					continue
 				fi
  			fi
+			total_freemem=`free -k | grep Mem: | awk '{print $7}'`
+			free_mem=`echo \($total_freemem/100\)*90 | bc`
+			#
+			# We are using arrays of 8 byte elements, and there are 3 of them.
+			#
+			actual_mem_use=`echo $cache_size_kb*24 | bc`
+			#
+			# Do not build if the free_mem is less then the amount of memory
+			# this array size requires.
+			#
+			if [ $free_mem -lt $actual_mem_use ]; then
+				echo Requested size, ${cache_size_kb}K, is too large.
+				continue
+			fi
 
 			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic"
 			echo $CC_CMD >> streams_build_options

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -169,7 +169,7 @@ build_images()
 			# Do not build if the free_mem is less then the amount of memory
 			# this array size requires.
 			#
-			if [ $free_mem -lt $actual_mem_use ]; then
+			if [[ $free_mem -lt $actual_mem_use ]]; then
 				echo Requested size, ${cache_size_kb}K, is too large.
 				continue
 			fi


### PR DESCRIPTION
# Description
This pr resolves a segmentation fault happening on tight memory systems (m7i.xlarge).  Issue is we are trying to run with an array size that exceeds the available free memory.
Fix: 
Check to see if the memory the array size requires exceeds 90% of the free memory available.
Note the amount of memory the array needs is 8*3 what ever size.  The size is actually the number of longs being used, and 3 is the number of arrays present.

# Before/After Comparison
Before change: Program segfaults
After Change: If memory required exceeds 90% of the available memory, a message of 
Requested size, <x>K, is too large.

# Clerical Stuff
This closes #42 
Relates to JIRA: RPOPC-318
