### PR TITLE
Picking up an extra field separtor after Array Size.

### DIFF
--- a/streams/streams_run
+++ b/streams/streams_run
@@ -56,7 +56,7 @@ test_name="streams"
 process_list()
 {
 	echo $number_sockets Socket >> ../results_${test_name}.csv
-	echo "Array sizes:"$array_size >> ../results_${test_name}.csv
+	echo "Array sizes"$array_size >> ../results_${test_name}.csv
 	echo Copy:$copy >> ../results_${test_name}.csv
 	echo Scale:$scale >> ../results_${test_name}.csv
 	echo Add:$add >> ../results_${test_name}.csv


### PR DESCRIPTION
# Description
Removes an extra field separtor.

# Before/After Comparison
Results file before change
# Test meta data end
1 Socket
Array sizes::84480k:168960k:337920k:675840k:84480k:168960k:337920k:675840k
Copy:111902:109151:64270:61192

Result file after change
# Test meta data end
1 Socket
Array sizes:84480k:168960k:337920k:675840k:84480k:168960k:337920k:675840k
Copy:111902:109151:64270:61192



# Clerical Stuff
This closes #44 


Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-360
