### PR TITLE
Fix header.

### DIFF
--- a/streams/streams_run
+++ b/streams/streams_run
@@ -104,6 +104,7 @@ process_results()
 		echo "$item" >> $data_file
 	done
 	sort -n -u -t : -k 3 -k 1  $data_file| grep -v ^buffer > ${data_file}.sorted
+	array_size=""
 	for asize in `cut -d':' -f 1 ${data_file}.sorted | sort -nu`; do
 		array_size=${array_size}":"${asize}
 	done


### PR DESCRIPTION
# Description
We are getting additional fields in the header.  This is caused by not clearing out the previous header before we process the next set of data.


# Before/After Comparison
Before:
Array sizes:107520k:215040k:430080k:107520k:215040k:430080k
After
Array sizes:107520k:215040k:430080k

# Clerical Stuff
This closes #48 


Relates to JIRA: RPOPC-431
