### PR TITLE
Update to use the packaging tool

### DIFF
--- a/streams/streams.json
+++ b/streams/streams.json
@@ -1,0 +1,40 @@
+{
+    "dependencies": {
+        "amzn": [
+            "gcc",
+            "bc",
+            "git",
+            "zip",
+            "unzip",
+            "numactl"
+        ],
+        "rhel": [
+            "gcc",
+            "bc",
+            "perf",
+            "zip",
+            "unzip",
+            "numactl"
+        ],
+        "sles": [
+            "gcc",
+            "make",
+            "bc",
+            "perf",
+            "git",
+            "unzip",
+            "zip",
+            "libnuma1",
+            "numactl"
+        ],
+        "ubuntu": [
+            "bc",
+            "zip",
+            "unzip",
+            "numactl",
+	    "libnuma-dev"
+        ],
+        "pip": [
+        ]
+    }
+}

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -393,6 +393,14 @@ if [ ! -f "/tmp/${test_name}.out" ]; then
 	${TOOLS_BIN}/invoke_test --test_name ${test_name} --command ${0} --options "${arguments}"
 	exit $?
 fi
+#
+# Install required packaging.
+#
+${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/streams.json --no_packages $to_no_pkg_install
+if [[ $? -ne 0 ]]; then
+                echo Packaging installed failed.
+                exit 1
+fi
 
 #
 # Define user options


### PR DESCRIPTION
# Description
Update the code to use packaging tool in an effort to make the wrappers more standalone.

# Before/After Comparison
Before: Wrapper depended on the user or Zathras to install the packages for it.
After: The wrapper will now install the packages it requires to run

# Clerical Stuff
This closes #53 

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-666

Tested with Amazon, RHEL, SUSE and Ubuntu.
