### PR TITLE
Add streams results metric data.

### DIFF
--- a/streams/openmetrics_streams_reset.txt
+++ b/streams/openmetrics_streams_reset.txt
@@ -1,0 +1,10 @@
+iteration 0
+running 0
+numthreads 0
+runtime NaN
+throughput NaN
+latency NaN
+Add NaN
+Copy NaN
+Scale NaN
+Triad NaN

--- a/streams/openmetrics_streams_reset.txt
+++ b/streams/openmetrics_streams_reset.txt
@@ -4,6 +4,8 @@ numthreads 0
 runtime NaN
 throughput NaN
 latency NaN
+array_size NaN
+sockets NaN
 Add NaN
 Copy NaN
 Scale NaN

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -294,7 +294,7 @@ record_pcp_results()
 	test=$1
 	results=$2
 	value=`grep ^${test}: $results | awk '{print $2}'`
-	result2pcp ${test} ${value}
+	results2pcp_add_value "${test}:${value}"
 }
 
 for sockets_add in 1 `seq 2 1 ${numa_nodes}`
@@ -334,17 +334,18 @@ do
 				echo GOMP_CPU_AFFINITY: $cpus_use
 			fi
 			if [[ $pcp -eq 1 ]]; then
-				result2pcp iteration $iteration
-				record_pcp_results Copy ${resultdir}/${resfile}
-				record_pcp_results Scale ${resultdir}/${resfile}
-				record_pcp_results Add ${resultdir}/${resfile}
-				record_pcp_results Triad ${resultdir}/${resfile}
+				results2pcp_add_value "iteration:$iteration"
+				for i in Copy Scale Add Triad; do
+					record_pcp_results $i ${resultdir}/${resfile}
+				done
+				results2pcp_add_value_commit
+				reset_pcp_om
 				stop_pcp_subset
 			fi
 		done
-	if [[ $pcp -eq 1 ]]; then
-		stop_pcp
-		shutdown_pcp
-	fi
+		if [[ $pcp -eq 1 ]]; then
+			stop_pcp
+			shutdown_pcp
+		fi
 	done
 done

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -297,6 +297,14 @@ record_pcp_results()
 	results2pcp_add_value "${test}:${value}"
 }
 
+if [[ $pcp -eq 1 ]]; then
+	echo "Start PCP"
+	mkdir -p $pcpdir
+	pcp_out=streams_opt_level_${optim}
+	setup_pcp
+	start_pcp ${pcpdir}/ $pcp_out $pcp_cfg
+fi
+
 for sockets_add in 1 `seq 2 1 ${numa_nodes}`
 do
 	worker=`echo ${numb_threads}*${sockets_add} | bc`
@@ -310,13 +318,6 @@ do
 	for stream_size in $streams_exec
 	do
 		total_sockets=$[$sockets_add]
-		if [[ $pcp -eq 1 ]]; then
-			echo "Start PCP"
-			mkdir -p $pcpdir
-			pcp_out=streams_size_${stream_size}_opt_level_${optim}_threads_${OMP_NUM_THREADS}_sockets_${total_sockets}
-			setup_pcp
-			start_pcp ${pcpdir}/ $pcp_out $pcp_cfg
-		fi
 		for iteration in $(seq 1 1 ${iterations})
 		do
 			if [[ $pcp -eq 1 ]]; then
@@ -335,6 +336,10 @@ do
 			fi
 			if [[ $pcp -eq 1 ]]; then
 				results2pcp_add_value "iteration:$iteration"
+				asize=`echo $stream_size | cut -d'.'  -f2 | sed "s/k//g"`
+				results2pcp_add_value "array_size:$asize"
+				results2pcp_add_value "numthreads:${OMP_NUM_THREADS}"
+				results2pcp_add_value "sockets:${total_sockets}"
 				for i in Copy Scale Add Triad; do
 					record_pcp_results $i ${resultdir}/${resfile}
 				done
@@ -343,9 +348,9 @@ do
 				stop_pcp_subset
 			fi
 		done
-		if [[ $pcp -eq 1 ]]; then
-			stop_pcp
-			shutdown_pcp
-		fi
 	done
 done
+if [[ $pcp -eq 1 ]]; then
+	stop_pcp
+	shutdown_pcp
+fi

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -287,6 +287,16 @@ echo Opt_lvl: $optim
 echo numa_nodes $numa_nodes
 cpus_use=""
 separ=""
+pcp_out=0
+
+record_pcp_results()
+{
+	test=$1
+	results=$2
+	value=`grep ^${test}: $results | awk '{print $2}'`
+	result2pcp ${test} ${value}
+}
+
 for sockets_add in 1 `seq 2 1 ${numa_nodes}`
 do
 	worker=`echo ${numb_threads}*${sockets_add} | bc`
@@ -297,20 +307,23 @@ do
 	separ=","
 	echo Running on cpus: $cpus_use
 	export GOMP_CPU_AFFINITY=$cpus_use
-	if [[ $pcp -eq 1 ]]; then
-		echo "Start PCP"
-		start_pcp ${pcpdir}/ streams $pcp_cfg
-	fi
-	for iteration in $(seq 1 1 ${iterations})
+	for stream_size in $streams_exec
 	do
-		for stream_size in $streams_exec
+		total_sockets=$[$sockets_add]
+		if [[ $pcp -eq 1 ]]; then
+			echo "Start PCP"
+			mkdir -p $pcpdir
+			pcp_out=streams_size_${stream_size}_opt_level_${optim}_threads_${OMP_NUM_THREADS}_sockets_${total_sockets}
+			setup_pcp
+			start_pcp ${pcpdir}/ $pcp_out $pcp_cfg
+		fi
+		for iteration in $(seq 1 1 ${iterations})
 		do
-			total_sockets=$[$sockets_add]
-			resfile=${stream_size}.out.threads_${OMP_NUM_THREADS}.numb_sockets_${total_sockets}_iter_${iteration}
-
 			if [[ $pcp -eq 1 ]]; then
 				start_pcp_subset
 			fi
+			resfile=${stream_size}.out.threads_${OMP_NUM_THREADS}.numb_sockets_${total_sockets}_iter_${iteration}
+
 			if [[ $resultdir != "" ]]; then
 				lscpu >> ${resultdir}/$resfile
 				echo GOMP_CPU_AFFINITY: $cpus_use >> ${resultdir}/${resfile}
@@ -322,15 +335,15 @@ do
 			fi
 			if [[ $pcp -eq 1 ]]; then
 		        	echo "Send result to PCP archive"
-				out="${stream_size}_iter_${test_iters}"
-        			result2pcp iteration_${iteration} ${out}
-	        		stop_pcp_subset
+				record_pcp_results Copy ${resultdir}/${resfile}
+				record_pcp_results Scale ${resultdir}/${resfile}
+				record_pcp_results Add ${resultdir}/${resfile}
+				record_pcp_results Triad ${resultdir}/${resfile}
+	      			stop_pcp_subset
 			fi
-
 		done
+	if [[ $pcp -eq 1 ]]; then
+		shutdown_pcp
+	fi
 	done
 done
-if [[ $pcp -eq 1 ]]; then
-	shutdown_pcp
-fi
-

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -334,15 +334,16 @@ do
 				echo GOMP_CPU_AFFINITY: $cpus_use
 			fi
 			if [[ $pcp -eq 1 ]]; then
-		        	echo "Send result to PCP archive"
+				result2pcp iteration $iteration
 				record_pcp_results Copy ${resultdir}/${resfile}
 				record_pcp_results Scale ${resultdir}/${resfile}
 				record_pcp_results Add ${resultdir}/${resfile}
 				record_pcp_results Triad ${resultdir}/${resfile}
-	      			stop_pcp_subset
+				stop_pcp_subset
 			fi
 		done
 	if [[ $pcp -eq 1 ]]; then
+		stop_pcp
 		shutdown_pcp
 	fi
 	done

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -183,7 +183,7 @@ retrieve_line()
 	items=0
 	calc_line=""
 
-	info=`grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | cut -d: -f  4`
+	info=`grep -h "${search_for}:" ${file}* | tr -s " " | sed "s/ /:/g" | tr -s ':' | cut -d: -f 2`
 
 	for i in $info; do
 		if [ $items -eq 0 ]; then

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -21,6 +21,8 @@ arguments="$@"
 array_size=""
 streams_wrapper_version=1.0
 curdir=`pwd`
+start_time=""
+end_time=""
 if [[ $0 == "./"* ]]; then
 	chars=`echo $0 | awk -v RS='/' 'END{print NR-1}'`
 	if [[ $chars == 1 ]]; then
@@ -35,6 +37,8 @@ else
 fi
 
 test_name="streams"
+export run_dir
+export test_name
 #
 # streams arguments
 #
@@ -59,10 +63,10 @@ process_list()
 {
 	echo $number_sockets Socket >> ../results_${test_name}.csv
 	echo "Array sizes"$array_size >> ../results_${test_name}.csv
-	echo Copy:$copy >> ../results_${test_name}.csv
-	echo Scale:$scale >> ../results_${test_name}.csv
-	echo Add:$add >> ../results_${test_name}.csv
-	echo Triad:$triad >> ../results_${test_name}.csv
+	echo Copy,$copy,$start_time,$end_time >> ../results_${test_name}.csv
+	echo Scale,$scale,$start_time,$end_time >> ../results_${test_name}.csv
+	echo Add,$add,$start_time,$end_time >> ../results_${test_name}.csv
+	echo Triad,$triad,$start_time,$end_time >> ../results_${test_name}.csv
 	echo "" >> ../results_${test_name}.csv
 	line_size=`echo $copy | wc -c`
 	if [ $line_size -lt 2 ]; then
@@ -108,8 +112,9 @@ process_results()
 	sort -n -u -t : -k 3 -k 1  $data_file| grep -v ^buffer > ${data_file}.sorted
 	array_size=""
 	for asize in `cut -d':' -f 1 ${data_file}.sorted | sort -nu`; do
-		array_size=${array_size}":"${asize}
+		array_size=${array_size}","${asize}
 	done
+	array_size="${array_size}",Start_Date,End_Date
 
 	#
 	# We have the data sorted, now go through things.  Each jump in number of sockets
@@ -160,7 +165,7 @@ process_results()
 		add=${add}${separ}$val
 		val=`echo $line | cut -d: -f 7`
 		triad=${triad}${separ}$val
-		separ=":"
+		separ=","
 	done < ${data_file}.sorted
 	rm ${data_file}.sorted 2> /dev/null
 	process_list
@@ -514,7 +519,16 @@ if [[ $to_use_pcp -eq 1 ]]; then
 	pdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
 	pcp="--pcp ${pdir}"
 fi
+#
+# We will need to revamp how the run is done and data is recorded to get
+# a more accurate view of run times.  Goal right now is to simply update the
+# results file with the time stamps.  How we output the results to the csv
+# file may have to change, but that is beyond the scope of the current work
+# of simply putting in timestamps
+#
+start_time=$(retrieve_time_stamp)
 streams_run
+end_time=$(retrieve_time_stamp)
 cd $curdir
 if [[ $results_dir == "" ]]; then
 	results_dir=results_streams_${tuned_setting}_$(date "+%Y.%m.%d-%H.%M.%S")


### PR DESCRIPTION
# Description
Streams pcp is broken, we are not setting anything properly.  This fixes that issue

# Before/After Comparison
Before: 
   Seeing:
       Logging results iteration_1 stream.36608k_iter_
       Unexpected metric logged. Check for a Typo

      pmrep -p -a streams.0 openmetrics.workload.stream.36608k_iter_
      Invalid metric openmetrics.workload.stream.36608k_iter_ (PM_ERR_NAME Unknown metric name).

After
    Above message not seen.
[root@ip-170-0-17-77 pcp_2026.01.09-12.59.58]# pmrep -p -a 
streams_size_stream.36608k_opt_level_2_threads_4_sockets_1.0 openmetrics.workload
pmrep -p -a streams_size_stream.36608k_opt_level_2_threads_4_sockets_1.0 openmetrics.workload
                      
          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.Add  o.w.Copy  o.w.Scale  o.w.Triad  o.w.array_size  o.w.sockets
17:03:18          1.000        1.000           4.000          NaN             NaN          NaN  27047.0  41276.60  26659.900  26913.100      107520.000        1.000
17:03:19          1.000        1.000           4.000          NaN             NaN          NaN  27047.0  41276.60  26659.900  26913.100      107520.000        1.000
17:03:35          1.000        1.000           4.000          NaN             NaN          NaN  27053.5  41442.40  26596.500  26755.100      215040.000        1.000
17:03:36          1.000        1.000           4.000          NaN             NaN          NaN  27053.5  41442.40  26596.500  26755.100      215040.000        1.000
17:04:00          1.000        1.000           4.000          NaN             NaN          NaN  27653.7  42038.90  27079.900  27382.500      430080.000        1.000
17:04:01          1.000        1.000           4.000          NaN             NaN          NaN  27653.7  42038.90  27079.900  27382.500      430080.000        1.000


Fix details:

Added openmetric file for Add, Copy, Scale, Triad, array size, number of sockets and number of threads.

Moved the array size and iteration loops so all iterations happens for a array size at once. 
 
pcp file only contains the optimization level in the name

Fix the following line  (separate commit)
info=`grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | cut -d: -f  4`
to be
info=`grep -h "${search_for}:" ${file}* | tr -s " " | sed "s/ /:/g" | tr -s ':' | cut -d: -f 2`

The -h eliminates the file name being the first field if we have multiple files working with.
The  tr -s ':' ensures that we have only a single ':' not multiples together.

# Clerical Stuff
This closes #56 


Relates to JIRA: RPOPC-758

Test results
Command executed
/home/ec2-user/workloads/streams-wrapper-2.1/streams/streams_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m5.xlarge" --sysname "m5.xlarge" --sys_type aws  --iterations 5 - --use_pcp
===============================
csv file
===============================
 1 Socket
Array sizes,107520k,215040k,430080k,Start_Date,End_Date
Copy,41276,41442,42038,2026-01-29T17:01:52Z,2026-01-29T17:04:08Z
Scale,26659,26596,27079,2026-01-29T17:01:52Z,2026-01-29T17:04:08Z
Add,27047,27053,27653,2026-01-29T17:01:52Z,2026-01-29T17:04:08Z
Triad,26913,26755,27382,2026-01-29T17:01:52Z,2026-01-29T17:04:08Z

=====================================
partial pcp output
=====================================
          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.Add  o.w.Copy  o.w.Scale  o.w.Triad  o.w.array_size  o.w.sockets
17:03:18          1.000        1.000           4.000          NaN             NaN          NaN  27047.0  41276.60  26659.900  26913.100      107520.000        1.000
17:03:19          1.000        1.000           4.000          NaN             NaN          NaN  27047.0  41276.60  26659.900  26913.100      107520.000        1.000
17:03:35          1.000        1.000           4.000          NaN             NaN          NaN  27053.5  41442.40  26596.500  26755.100      215040.000        1.000
17:03:36          1.000        1.000           4.000          NaN             NaN          NaN  27053.5  41442.40  26596.500  26755.100      215040.000        1.000
17:04:00          1.000        1.000           4.000          NaN             NaN          NaN  27653.7  42038.90  27079.900  27382.500      430080.000        1.000
17:04:01          1.000        1.000           4.000          NaN             NaN          NaN  27653.7  42038.90  27079.900  27382.500      430080.000        1.000



=========================
Streams run ouput.
=========================
[streams_out.txt](https://github.com/user-attachments/files/24943953/streams_out.txt)




