### PR TITLE
Fix streams output

### DIFF
--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-ntimes=1000
 iterations=10
 tuned_config="None"
 optim=3
@@ -47,7 +46,6 @@ ARGUMENT_LIST=(
 	"cache_start_size"
 	"host"
 	"iterations"
-	"ntimes"
 	"numb_sizes"
 	"optimize_lvl"
 	"pcpdir"
@@ -93,10 +91,6 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--iterations)
 			iterations=${2}
-			shift 2
-		;;
-		--ntimes)
-			ntimes=${2}
 			shift 2
 		;;
 		--numb_sizes)
@@ -194,7 +188,7 @@ build_images()
 				continue
 			fi
 
-			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} -DNTIMES=${ntimes} stream_omp_5_10.c -o ${stream} -fno-pic"
+			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic"
 			echo $CC_CMD >> streams_build_options
 			$CC_CMD
 			if [ $? -ne 0 ]; then
@@ -226,8 +220,8 @@ build_images()
 			else
 				streams_exec=$streams_exec" "$stream
 			fi
-			echo gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} -DNTIMES=${ntimes} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options
-			gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} -DNTIMES=${ntimes} stream_omp_5_10.c -o ${stream} -fno-pic
+			echo gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options
+			gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} stream_omp_5_10.c -o ${stream} -fno-pic
 			if [ $? -ne 0 ]; then
 				echo Compilation of streams failed.
 				exit 1

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+ntimes=1000
 iterations=10
 tuned_config="None"
 optim=3
@@ -46,6 +47,7 @@ ARGUMENT_LIST=(
 	"cache_start_size"
 	"host"
 	"iterations"
+	"ntimes"
 	"numb_sizes"
 	"optimize_lvl"
 	"pcpdir"
@@ -91,6 +93,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--iterations)
 			iterations=${2}
+			shift 2
+		;;
+		--ntimes)
+			ntimes=${2}
 			shift 2
 		;;
 		--numb_sizes)
@@ -188,7 +194,7 @@ build_images()
 				continue
 			fi
 
-			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic"
+			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} -DNTIMES=${ntimes} stream_omp_5_10.c -o ${stream} -fno-pic"
 			echo $CC_CMD >> streams_build_options
 			$CC_CMD
 			if [ $? -ne 0 ]; then
@@ -220,8 +226,8 @@ build_images()
 			else
 				streams_exec=$streams_exec" "$stream
 			fi
-			echo gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options
-			gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} stream_omp_5_10.c -o ${stream} -fno-pic
+			echo gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} -DNTIMES=${ntimes} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options
+			gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} -DNTIMES=${ntimes} stream_omp_5_10.c -o ${stream} -fno-pic
 			if [ $? -ne 0 ]; then
 				echo Compilation of streams failed.
 				exit 1

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -183,7 +183,7 @@ retrieve_line()
 	items=0
 	calc_line=""
 
-	info=`grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | sed "s/::/:/g" | cut -d: -f 2`
+	info=`grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | tr -s ':' | cut -d: -f 2`
 
 	for i in $info; do
 		if [ $items -eq 0 ]; then

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-ntimes=1000
 arguments="$@"
 array_size=""
 streams_wrapper_version=1.0
@@ -184,7 +183,7 @@ retrieve_line()
 	items=0
 	calc_line=""
 
-	info=grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | tr -s ':' | cut -d: -f 2
+	info=`grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | sed "s/::/:/g" | cut -d: -f 2`
 
 	for i in $info; do
 		if [ $items -eq 0 ]; then
@@ -290,8 +289,8 @@ set_up_test()
 run_stream()
 {
 	cd $run_dir
-	echo ./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir $pcp --ntimes $ntimes
-	./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir > /tmp/streams_results/${2}_opt_${1} $pcp --ntimes $ntimes
+	echo ./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir $pcp
+	./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir > /tmp/streams_results/${2}_opt_${1} $pcp
 	if [ $? -ne 0 ]; then
 		echo "Execution of run stream failed."
 		exit 1
@@ -319,7 +318,6 @@ usage()
 	echo "    Default is 1"
 	echo "--cache_cap_size <value>: Caps the size of cache to this value.  Default is no cap."
 	echo "--nsizes <value>:  Maximum number of cache sizes to do. Default is 4"
-	echo "--ntimes <value>:  Number of times for streams test to run the test (default is 1000)".
 	echo "--opt2 <value>:  If value is not 0, then we will run with optimization level"
 	echo "    2.  Default value is 1"
 	echo "--opt3 <value>:  If value is not 0, then we will run with optimization level"
@@ -412,7 +410,6 @@ ARGUMENT_LIST=(
 	"cache_multiply"
 	"cache_start_factor"
 	"nsizes"
-	"ntimes"
 	"opt2"
 	"opt3"
 	"results_dir"
@@ -462,10 +459,6 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--nsizes)
 			nsizes=${2}
-			shift 2
-		;;
-		--ntimes)
-			ntimes=${2}
 			shift 2
 		;;
 		--opt2)

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -184,7 +184,7 @@ retrieve_line()
 	items=0
 	calc_line=""
 
-	info=`grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | cut -d: -f  4`
+	info=grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | tr -s ':' | cut -d: -f 2
 
 	for i in $info; do
 		if [ $items -eq 0 ]; then

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+ntimes=1000
 arguments="$@"
 array_size=""
 streams_wrapper_version=1.0
@@ -289,8 +290,8 @@ set_up_test()
 run_stream()
 {
 	cd $run_dir
-	echo ./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir $pcp
-	./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir > /tmp/streams_results/${2}_opt_${1} $pcp
+	echo ./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir $pcp --ntimes $ntimes
+	./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir > /tmp/streams_results/${2}_opt_${1} $pcp --ntimes $ntimes
 	if [ $? -ne 0 ]; then
 		echo "Execution of run stream failed."
 		exit 1
@@ -318,6 +319,7 @@ usage()
 	echo "    Default is 1"
 	echo "--cache_cap_size <value>: Caps the size of cache to this value.  Default is no cap."
 	echo "--nsizes <value>:  Maximum number of cache sizes to do. Default is 4"
+	echo "--ntimes <value>:  Number of times for streams test to run the test (default is 1000)".
 	echo "--opt2 <value>:  If value is not 0, then we will run with optimization level"
 	echo "    2.  Default value is 1"
 	echo "--opt3 <value>:  If value is not 0, then we will run with optimization level"
@@ -410,6 +412,7 @@ ARGUMENT_LIST=(
 	"cache_multiply"
 	"cache_start_factor"
 	"nsizes"
+	"ntimes"
 	"opt2"
 	"opt3"
 	"results_dir"
@@ -459,6 +462,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--nsizes)
 			nsizes=${2}
+			shift 2
+		;;
+		--ntimes)
+			ntimes=${2}
 			shift 2
 		;;
 		--opt2)


### PR DESCRIPTION
# Description
The line info=`grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g" | cut -d: -f  4` can result in having multiple : in place this makes sure there is only 1 : in place. 

Output from each section of problematic line
grep "${search_for}" ${file}*
Triad:          25358.1     0.071231     0.070958     0.071677
grep "${search_for}" ${file}* | tr -s " "
Triad: 25358.1 0.071231 0.070958 0.071677
grep "${search_for}" ${file}* | tr -s " " | sed "s/ /:/g"
Triad::25358.1:0.071231:0.070958:0.071677

when fix, the :: will disappear.  

# Before/After Comparison
On broken system we see this in the csv file

1 Socket
Array sizes:36608k:73216k:146432k:292864k
Copy:0:0:0:0
Scale:0:0:0:0
Add:23:23:23:23
Triad:0:0:0:0

When fixed, we see
1 Socket
Array sizes:36608k:73216k:146432k:292864k
Copy:21435:21424:21420:22385
Scale:24511:24538:24493:24523
Add:12595:12597:12564:12582
Triad:25123:25152:25095:25126

# Clerical Stuff
This closes #58 

Relates to JIRA: RPOPC-771

Test results

Command executed
/home/ec2-user/workloads/streams-wrapper-2.1_working/streams/streams_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m5.xlarge" --sysname "m5.xlarge" --sys_type aws  --opt3 0

PCP Output

Streams has not been updated yet.

csv output (successful run)
1 Socket
Array sizes:36608k:73216k:146432k:292864k
Copy:21435:21424:21420:22385
Scale:24511:24538:24493:24523
Add:12595:12597:12564:12582
Triad:25123:25152:25095:25126

-x output from wrapper success
[streams_x.txt](https://github.com/user-attachments/files/24735145/streams_x.txt)

