### PR TITLE
Update pull test_tools

### DIFF
--- a/streams/streams_run
+++ b/streams/streams_run
@@ -79,7 +79,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." 101
+                        exit "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -61,15 +61,44 @@ TOOLS_BIN="${HOME}/test_tools"
 export TOOLS_BIN
 tools_git=https://github.com/redhat-performance/test_tools-wrappers
 
-if [ ! -d "${TOOLS_BIN}" ]; then
-        git clone $tools_git ${TOOLS_BIN}
-        if [ $? -ne 0 ]; then
-                echo pulling git $tools_git failed.
-                exit 101
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
         fi
-else
-	echo Found an existing test_tools directory, using it.
-fi
+}
+
+attempt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 101
+                fi
+        fi
+}
+
+attempt_tools_wget
+attempt_tools_curl
+attempt_tools_git
+
 source ${TOOLS_BIN}/error_codes
 
 #

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -61,22 +61,11 @@ TOOLS_BIN="${HOME}/test_tools"
 export TOOLS_BIN
 tools_git=https://github.com/redhat-performance/test_tools-wrappers
 
-attempt_tools_wget()
+attempt_tools_generic()
 {
+	method="$1"
         if [[ ! -d "$TOOLS_BIN" ]]; then
-                wget ${tools_git}/archive/refs/heads/main.zip
-                if [[ $? -eq 0 ]]; then
-                        unzip -q main.zip
-                        mv test_tools-wrappers-main ${TOOLS_BIN}
-                        rm main.zip
-                fi
-        fi
-}
-
-attempt_tools_curl()
-{
-        if [[ ! -d "$TOOLS_BIN" ]]; then
-                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                $method ${tools_git}/archive/refs/heads/main.zip
                 if [[ $? -eq 0 ]]; then
                         unzip -q main.zip
                         mv test_tools-wrappers-main ${TOOLS_BIN}
@@ -95,8 +84,8 @@ attempt_tools_git()
         fi
 }
 
-attempt_tools_wget
-attempt_tools_curl
+attempt_tools_generic "wget"
+attempt_tools_generic "curl -L -O "
 attempt_tools_git
 
 source ${TOOLS_BIN}/error_codes

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -79,7 +79,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                       echo "Error: pulling git $tools_git failed."
+                       echo "Error: pulling git $tools_git failed." >&2
 		       exit 101
                 fi
         fi

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -79,7 +79,8 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit "Error: pulling git $tools_git failed." 101
+                       echo "Error: pulling git $tools_git failed."
+		       exit 101
                 fi
         fi
 }


### PR DESCRIPTION
# Description

Update how we are pulling test_tools

# Before/After Comparison
Before: We only used git, if git was not present, we would fail.
After: We now try git, curl and wget.

# Clerical Stuff
This closes #62 

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-880

Testing done
Ran the following scenario file
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: streams_res
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "streams"
    host_config: "m5.xlarge"

csv file generated
Array_sizes,36608k,73216k,146432k,292864k,Start_Date,End_Date
Copy,8687,9375,9745,10197,2026-03-14T14:54:55Z,2026-03-14T15:10:51Z
Scale,9728,10054,11000,11448,2026-03-14T14:54:55Z,2026-03-14T15:10:51Z
Add,10738,10902,11986,11962,2026-03-14T14:54:55Z,2026-03-14T15:10:51Z
Triad,10689,11284,11996,12009,2026-03-14T14:54:55Z,2026-03-14T15:10:51Z


