### PR TITLE
Convert to using package_tool function from general_setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+stream.*k
+run_stream

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -421,7 +421,7 @@ fi
 #
 # Install required packaging.
 #
-${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/streams.json --no_packages $to_no_pkg_install
+package_tool --wrapper_config ${run_dir}/streams.json
 lrtc=$?
 if [[ $? -ne $lrtc ]]; then
 	echo Packaging installed failed.


### PR DESCRIPTION
# Description
Uses the package_tool function from general setup, allowing all global flags to be passed without updating this wrapper in the future.

# Before/After Comparison
## Before
Each flag passed to package_tool would need to be provided individually

## After
general_setup provides all relevant global package_tool flags

# Clerical Stuff
This closes #64 

Relates to JIRA: RPOPC-884
