### PR TITLE
Fix test_tools path for detect_numa

### DIFF
--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -233,7 +233,7 @@ build_images()
 
 setup_sizing()
 {
-	numa_nodes=`$top_dir/test_tools/detect_numa --node-count`
+	numa_nodes=`${TOOLS_BIN}/detect_numa --node-count`
 
 	if [ $optim -eq 3 ]; then
 		echo Optimization=O3
@@ -311,7 +311,7 @@ do
 	worker=`echo ${numb_threads}*${sockets_add} | bc`
 	export OMP_NUM_THREADS=$worker
 	let "node_index=$sockets_add-1"
-	cpu_numa=`$top_dir/test_tools//detect_numa -n $node_index --cpu-list`
+	cpu_numa=`${TOOLS_BIN}/detect_numa -n $node_index --cpu-list`
 	cpus_use=${cpus_use}${separ}${cpu_numa}
 	separ=","
 	echo Running on cpus: $cpus_use


### PR DESCRIPTION
# Description
Provides proper path to detect_numa

# Before/After Comparison
Before: Failure with message 
./run_stream: line 236: /home/ec2-user/test_tools/detect_numa: No such file or directory
(standard_in) 2: syntax error
(standard_in) 1: syntax error
./run_stream: line 314: /home/ec2-user/test_tools//detect_numa: No such file or directory

libgomp: Invalid value for environment variable OMP_NUM_THREADS: 

After: Ran successfully and produce results as expected.

# Clerical Stuff
This closes #66 

Relates to JIRA: RPOPC-888

Testing
Ran streams on test system
Before change, we failed on detect_numa
After change, we produced the expected results

csv file
Array_sizes,36608k,73216k,146432k,292864k,Start_Date,End_Date
Copy,77813,80257,80115,79999,2026-03-19T14:07:14Z,2026-03-19T14:15:58Z
Scale,63074,62899,62624,62493,2026-03-19T14:07:14Z,2026-03-19T14:15:58Z
Add,71302,70123,69988,69861,2026-03-19T14:07:14Z,2026-03-19T14:15:58Z
Triad,70991,70483,70076,69959,2026-03-19T14:07:14Z,2026-03-19T14:15:58Z
