### PR TITLE
Handle multiple runs in the same results file.

### DIFF
--- a/streams/streams_run
+++ b/streams/streams_run
@@ -76,6 +76,27 @@ source ${TOOLS_BIN}/error_codes
 # Report results
 #
 
+validate_data()
+{
+	tmpfile=$1
+
+	${TOOLS_BIN}/csv_to_json $to_json_flags --transpose --csv_file ${tmpfile}_worker --output_file results_streams.json
+	lrtc=$?
+	if [[ $lrtc -ne 0 ]]; then
+		echo "Verification of streams data failed"
+		exit $lrtc
+	fi
+	${TOOLS_BIN}/verify_results $to_verify_flags --schema_file $script_dir/results_schema.py --class_name Streams_Results --file results_streams.json
+	lrtc=$?
+	if [[ $lrtc -ne 0 ]]; then
+		echo Verification of streams data failed.
+		rtc=$ltrc
+	fi
+}
+
+#
+# Break each numa node run into its own file before we validate the data.
+#
 process_list()
 {
 	echo "# $number_sockets Socket" >> $csv_file
@@ -92,20 +113,23 @@ process_list()
 	#
 	tmpfile=$(mktemp /tmp/streams_reduce_.XXXXXX)
 	cut -d',' -f1-4 $csv_file > $tmpfile
-	${TOOLS_BIN}/csv_to_json $to_json_flags --transpose --csv_file $tmpfile --output_file results_streams.json
-	lrtc=$?
-	if [[ $lrtc -ne 0 ]]; then
-		echo "Verification of streams data failed"
-		exit $lrtc
-	fi	
-	${TOOLS_BIN}/verify_results $to_verify_flags --schema_file $script_dir/results_schema.py --class_name Streams_Results --file results_streams.json
-	lrtc=$?
-	if [[ $lrtc -ne 0 ]]; then
-		echo Verification of streams data failed.
-		rtc=$ltrc
-	fi
-	rm $tmpfile
-	rm -f results_streams.json
+	created=0
+	while IFS= read -r run_data
+	do
+		if [[ $run_data == *"Socket"* ]]; then
+			if [[ $created -eq 1 ]]; then
+				validate_data ${tmpfile}
+				rm -f ${tmpfile}_worker results_streams.json
+				continue
+			fi
+			created=1
+		fi
+		if [[ $created -eq 1 ]]; then
+			echo $run_data >> ${tmpfile}_worker
+		fi
+	done < "${tmpfile}"
+	validate_data ${tmpfile}
+	rm -f results_streams.json $tmpfile ${tmpfile}_worker
 }
 
 process_results()


### PR DESCRIPTION
# Description
Fixes verification from breaking when multiple numa nodes are present

# Before/After Comparison
Before: No results given, as verification of data failed.
After: Verification of results passes as expected.

# Clerical Stuff
This closes #68 

Relates to JIRA: RPOPC-916

Testing done:
Reran the failed tests on the cloud systems that failed.  Test now provides results

csv file generate (m5.24xlarge)

 Test meta data start
# Optimization level: O3
# kernel_rev      --meta_output numa_nodes
# number_cpus 
# Core\(s\)_per_socket 
# Model_name 
# streams_version_# 5.10
# Test meta data end
# 1 Socket
Array_sizes,33792k,67584k,135168k,270336k,Start_Date,End_Date
Copy,85318,89418,83180,81572,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z
Scale,66025,65270,66525,63295,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z
Add,72799,72935,73304,70482,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z
Triad,73800,72691,73237,70221,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z

# 2 Socket
Array_sizes,33792k,67584k,135168k,270336k,Start_Date,End_Date
Copy,85318,89418,83180,81572,177430,178596,180551,162963,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z
Scale,66025,65270,66525,63295,135927,134586,132276,130853,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z
Add,72799,72935,73304,70482,150073,148275,147031,144438,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z
Triad,73800,72691,73237,70221,152270,149346,147477,144377,2026-03-30T12:20:51Z,2026-03-30T12:37:07Z

