### PR TITLE
Add option to designate the build option NTIME

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Streams Options:
   --cache_start_factor <value>: Start the cache size at base cache * <value>. Default is 1.
   --cache_cap_size <value>: Caps the size of cache to this value. Default is no cap (0).
   --nsizes <value>: Maximum number of cache sizes to test. Default is 4.
+  --ntimes <value>: Sets the compile flag NTIMES to value x. The streams run will"
+    report the best value of the x runs.
   --opt2 <value>: If value is not 0, run with O2 optimization level. Default is 1.
   --opt3 <value>: If value is not 0, run with O3 optimization level. Default is 1.
   --result_dir <string>: Directory to place results into. Default is

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -47,6 +47,7 @@ ARGUMENT_LIST=(
 	"cache_start_size"
 	"host"
 	"iterations"
+	"ntimes"
 	"numb_sizes"
 	"optimize_lvl"
 	"pcpdir"
@@ -92,6 +93,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--iterations)
 			iterations=${2}
+			shift 2
+		;;
+		--ntimes)
+			ntimes=${2}
 			shift 2
 		;;
 		--numb_sizes)
@@ -189,7 +194,7 @@ build_images()
 				continue
 			fi
 
-			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic"
+			CC_CMD="gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DNTIMES=${ntimes} -DSTREAM_ARRAY_SIZE=${use_cache} stream_omp_5_10.c -o ${stream} -fno-pic"
 			echo $CC_CMD >> streams_build_options
 			$CC_CMD
 			if [ $? -ne 0 ]; then

--- a/streams/streams_extra/run_stream
+++ b/streams/streams_extra/run_stream
@@ -227,7 +227,7 @@ build_images()
 				streams_exec=$streams_exec" "$stream
 			fi
 			echo gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} stream_omp_5_10.c -o ${stream} -fno-pic >> streams_build_options
-			gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DSTREAM_ARRAY_SIZE=${test_size} stream_omp_5_10.c -o ${stream} -fno-pic
+			gcc ${MOPT} -fopenmp  -mcmodel=large ${optim_opt} -DNTIMES=${ntimes} -DSTREAM_ARRAY_SIZE=${test_size} stream_omp_5_10.c -o ${stream} -fno-pic
 			if [ $? -ne 0 ]; then
 				echo Compilation of streams failed.
 				exit $E_GENERAL

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -24,6 +24,8 @@ array_size=""
 streams_wrapper_version=1.0
 curdir=`pwd`
 start_time=""
+ntimes=100
+
 end_time=""
 if [[ $0 == "./"* ]]; then
 	chars=`echo $0 | awk -v RS='/' 'END{print NR-1}'`
@@ -369,8 +371,8 @@ set_up_test()
 run_stream()
 {
 	cd $run_dir
-	echo ./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir $pcp
-	./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir > /tmp/streams_results/${2}_opt_${1} $pcp
+	echo ./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir $pcp --ntimes $ntimes
+	./run_stream --cache_cap_size ${cache_cap_size} --iterations ${to_times_to_run}  --cache_start_size $cache_start_factor --optimize_lvl ${1} --cache_multiply $cache_multiply --numb_sizes $nsizes --thread_multiply $threads_multiple --results_dir ${results_dir} --host ${to_configuration} --size_list ${size_list} --top_dir $curdir > /tmp/streams_results/${2}_opt_${1} $pcp --ntimes $ntimes
 	if [ $? -ne 0 ]; then
 		echo "Execution of run stream failed."
 		exit $E_GENERAL
@@ -398,6 +400,8 @@ usage()
 	echo "    Default is 1"
 	echo "--cache_cap_size <value>: Caps the size of cache to this value.  Default is no cap."
 	echo "--nsizes <value>:  Maximum number of cache sizes to do. Default is 4"
+	echo "--ntimes <value>:  Sets the compile flag NTIMES to value x. The streams run will"
+	echo "    report the best value of the x runs. Default value is 100"
 	echo "--opt2 <value>:  If value is not 0, then we will run with optimization level"
 	echo "    2.  Default value is 1"
 	echo "--opt3 <value>:  If value is not 0, then we will run with optimization level"
@@ -479,6 +483,7 @@ ARGUMENT_LIST=(
 	"cache_multiply"
 	"cache_start_factor"
 	"nsizes"
+	"ntimes"
 	"opt2"
 	"opt3"
 	"results_dir"
@@ -528,6 +533,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--nsizes)
 			nsizes=${2}
+			shift 2
+		;;
+		--ntimes)
+			ntimes=${2}
 			shift 2
 		;;
 		--opt2)


### PR DESCRIPTION
# Description
Adds an option to allow us to designate the NTIME build option.    This build option tells the streams code to run x times and provide the best results.

# Before/After Comparison
Before:  Seeing variations from run to run.
After:  If variations are present, use the ntime option to increase NTIME build option.  Default is 100.

# Clerical Stuff
This closes #55 

Relates to JIRA: RPOPC-695

Testing

Verified the --ntime option is impacting the run time of streams

set to 10
real    8m37.110s
user    3m38.759s
sys     0m20.636s

Set to 100
real    15m54.233s
user    31m59.629s
sys     0m20.912s

csv file produced

Array_sizes,8192k,16384k,32768k,65536k,Start_Date,End_Date
Copy,28714,29358,29702,29674,2026-05-08T12:35:19Z,2026-05-08T12:50:57Z
Scale,20639,20342,20140,20086,2026-05-08T12:35:19Z,2026-05-08T12:50:57Z
Add,21829,21834,20361,20427,2026-05-08T12:35:19Z,2026-05-08T12:50:57Z
Triad,21946,21925,20368,20427,2026-05-08T12:35:19Z,2026-05-08T12:50:57Z

Documentation updated.