### PR TITLE
Remove extra fields when more then 1 socket is being used.

### DIFF
--- a/streams/streams_run
+++ b/streams/streams_run
@@ -248,6 +248,7 @@ process_results()
 		triad=${triad}${separ}$val
 		separ=","
 	done < ${data_file}.sorted
+	rm ${data_file}.sorted 2> /dev/null
 	process_list
 }
 

--- a/streams/streams_run
+++ b/streams/streams_run
@@ -186,7 +186,7 @@ process_results()
 		let "item_count=${item_count}+1"
 		echo "$item" >> $data_file
 	done
-	sort -n -u -t : -k 3 -k 1  $data_file| grep -v ^buffer > ${data_file}.sorted
+	sort -n -u -t : -k 3,3 -k 1,1  $data_file| grep -v ^buffer > ${data_file}.sorted
 	array_size=""
 	for asize in `cut -d':' -f 1 ${data_file}.sorted | sort -nu`; do
 		array_size=${array_size}","${asize}
@@ -211,6 +211,11 @@ process_results()
 		else
 			if [ $current_socket -ne $number_sockets ]; then
 				process_list
+				copy=""
+				scale=""
+				add=""
+				triad=""
+				separ=""
 			fi
 			number_sockets=$current_socket
 		fi
@@ -243,7 +248,6 @@ process_results()
 		triad=${triad}${separ}$val
 		separ=","
 	done < ${data_file}.sorted
-	rm ${data_file}.sorted 2> /dev/null
 	process_list
 }
 


### PR DESCRIPTION
# Description
Currently if more then 1 socket is being tested, we will output the results of the current socket, and all the priors reported.  This corrects this issue so we report just the socket, not the priors.

# Before/After Comparison
Before: Possible to have extra data in the csv file.
After: Just the data associated with the number of sockets is given.

# Clerical Stuff
This closes #74

Relates to JIRA: RPOPC-1427

Testing:
Ran the new code, verified that the results is as expected.

1 Socket
Array_sizes,32768k,65536k,131072k,262144k,Start_Date,End_Date
Copy,52713,48770,47253,68802,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z
Scale,47161,46980,46577,46475,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z
Add,49396,50419,50765,50951,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z
Triad,51307,51278,51189,51156,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z

2 Socket
Array_sizes,32768k,65536k,131072k,262144k,Start_Date,End_Date
Copy,121976,104675,97100,94202,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z
Scale,102159,93810,93555,92909,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z
Add,99715,98452,100289,101135,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z
Triad,102310,102214,102079,102029,2026-07-21T08:50:30Z,2026-07-21T09:25:06Z


